### PR TITLE
#6 UISwitch 애니메이션 hitches 수정

### DIFF
--- a/BindingWithCell/CombineViewController.swift
+++ b/BindingWithCell/CombineViewController.swift
@@ -67,7 +67,8 @@ extension CombineViewController: UITableViewDelegate, UITableViewDataSource {
         bag[id]?.cancel()
         bag[id] = cell.$isOn.dropFirst()
             .removeDuplicates()
-            .subscribe(on: DispatchQueue.main)
+//            .subscribe(on: DispatchQueue.main)
+            .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
             .sink { [weak self] isOn in
                 self?.data[indexPath.row].isOn = isOn
                 self?.tableView.reloadData()

--- a/BindingWithCell/RxViewController.swift
+++ b/BindingWithCell/RxViewController.swift
@@ -67,6 +67,7 @@ extension RxViewController: UITableViewDelegate, UITableViewDataSource {
         disposeDict[id]?.dispose()
         disposeDict[id] = cell.toggleSwitch.rx.isOn.changed.asDriver()
             .distinctUntilChanged()
+            .debounce(.milliseconds(300))
             .drive(onNext: { [weak self] isOn in
                 self?.data[indexPath.row].isOn = isOn
                 self?.tableView.reloadData()


### PR DESCRIPTION
- `Debounce`를 사용해서 `UISwitch`가 토글 애니메이션을 할 수 있는 충분한 시간을 주었다.
- Combine의 경우 `Debounce`에서 스케쥴러를 사용하므로 `.subscribe(on: DispatchQueue.main)` 가 필요 없을거라고 예상했고 실제 동작에서도 문제 없어서 제거하였다.